### PR TITLE
MRG: Put back missing comma in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
     'jupyterlab',
     'ipykernel',
     'wget',
-    'seaborn'
+    'seaborn',
     'plotly',
     'statsmodels'
 ]


### PR DESCRIPTION
Otherwise pip install gives:

```
ERROR: Could not find a version that satisfies the requirement
seabornplotly (from algo-ecg) (from versions: none) ERROR: No matching
distribution found for seabornplotly
```